### PR TITLE
Add French localization

### DIFF
--- a/UTM Snapshot-Manager.xcodeproj/project.pbxproj
+++ b/UTM Snapshot-Manager.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		3DBDAC4F29B3642F009D0F73 /* QemuImg.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QemuImg.swift; sourceTree = "<group>"; };
 		3DBDAC5129B366BA009D0F73 /* Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
 		3DBDAC5329B36AE1009D0F73 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
+		F52335F82A1D356E00659292 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = "fr.lproj/UTM Snapshot-Manager-InfoPlist.strings"; sourceTree = "<group>"; };
+		F52335F92A1D357400659292 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -150,6 +152,7 @@
 				en,
 				de,
 				Base,
+				fr,
 			);
 			mainGroup = 3DBDAC1629B27B65009D0F73;
 			packageReferences = (
@@ -204,6 +207,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				3DACFFEF29BAAABE003A75A2 /* de */,
+				F52335F92A1D357400659292 /* fr */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -212,6 +216,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				3DACFFF729BB81C8003A75A2 /* de */,
+				F52335F82A1D356E00659292 /* fr */,
 			);
 			name = "UTM Snapshot-Manager-InfoPlist.strings";
 			path = "UTM Snapshot-Manager";
@@ -347,10 +352,11 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 2C77986N3B;
+				DEVELOPMENT_TEAM = YG57WKQ4Q3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -375,10 +381,11 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 2C77986N3B;
+				DEVELOPMENT_TEAM = YG57WKQ4Q3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/UTM Snapshot-Manager/QemuImg.swift
+++ b/UTM Snapshot-Manager/QemuImg.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 class QemuImg {
-    private static let qemuImgPath = "/opt/homebrew/bin/qemu-img"
-    
+    private static let qemuImgPath = FileManager.default.fileExists(atPath:"/usr/local/bin/qemu-img") ? "/usr/local/bin/qemu-img" : "/opt/homebrew/bin/qemu-img"
+
     private static let snapshotLinePattern = /^\d+.*?\n/.anchorsMatchLineEndings()
     private static let idPattern = /^\d+/
     private static let tagPattern = /^\d+\s+(?<tag>.*?)\s/

--- a/UTM Snapshot-Manager/fr.lproj/Localizable.strings
+++ b/UTM Snapshot-Manager/fr.lproj/Localizable.strings
@@ -1,0 +1,108 @@
+/* No comment provided by engineer. */
+"Add more VMs" = "Ajouter des VM";
+
+/* No comment provided by engineer. */
+"Add more VMs to this group" = "Ajouter une VM à ce groupe";
+
+/* No comment provided by engineer. */
+"Add Snapshot" = "Nouveau snapshot";
+
+/* No comment provided by engineer. */
+"Create" = "Créer";
+
+/* No comment provided by engineer. */
+"Create a new snapshot for all images in this group" = "Créer un nouveau snapshot pour toutes les images de ce groupe";
+
+/* No comment provided by engineer. */
+"Create new snapshot" = "Créer un nouveau snapshot";
+
+/* No comment provided by engineer. */
+"Creation date" = "Date de création";
+
+/* No comment provided by engineer. */
+"ID" = "ID";
+
+/* No comment provided by engineer. */
+"Name:" = "Nom :";
+
+/* No comment provided by engineer. */
+"New name:" = "Nouveau Nom :";
+
+/* No comment provided by engineer. */
+"New…" = "Nouvau…";
+
+/* Default name for new group */
+"NewGroup" = "NouveauGroupe";
+
+/* No comment provided by engineer. */
+"Please select a VM group on the left to display and edit the contained VMs, images and snapshots." = "Veuillez choisir un groupe de VM dans le panneau de navigation pour afficher et éditer les VM contenues, les images disques et snapshots.";
+
+/* No comment provided by engineer. */
+"Remove" = "Effacer";
+
+/* No comment provided by engineer. */
+"Remove latest snapshot" = "Effacer le dernier snapshot";
+
+/* No comment provided by engineer. */
+"Remove latest snapshot for all images in this group?" = "Effacer le dernier snapshot pour toutes les images disques de ce groupe ?";
+
+/* No comment provided by engineer. */
+"Remove selected snapshot?" = "Effacer le snapshot sélectionné?";
+
+/* No comment provided by engineer. */
+"Remove Snapshot" = "Effacer le snapshot";
+
+/* No comment provided by engineer. */
+"Remove the latest snapshot for all images in this group" = "Effacer le dernier snapshot pour toutes les images disques du groupe";
+
+/* No comment provided by engineer. */
+"Remove the selected group?" = "Effacer le groupe sélectionné ?";
+
+/* No comment provided by engineer. */
+"Remove this VM from the group?" = "Retirer cette VM du groupe ?";
+
+/* No comment provided by engineer. */
+"Remove VM" = "Retirer la VM";
+
+/* No comment provided by engineer. */
+"Rename" = "Renommer";
+
+/* No comment provided by engineer. */
+"Restore" = "Restaurer";
+
+/* No comment provided by engineer. */
+"Restore latest snapshot" = "Restaurer le dernier snapshot";
+
+/* No comment provided by engineer. */
+"Restore latest snapshot for all images in this group?" = "Restaurer le dernier snapshot pour toutes les images disques du groupe ?";
+
+/* No comment provided by engineer. */
+"Restore selected snapshot?" = "Restaurer le snapshot sélectionné ?";
+
+/* No comment provided by engineer. */
+"Restore Snapshot" = "Restaurer le snapshot";
+
+/* No comment provided by engineer. */
+"Restore the latest snapshot for all images in this group" = "Restaurer le dernier snapshot pour toutes les images disques du groupe";
+
+/* No comment provided by engineer. */
+"Tag" = "Tag";
+
+/* No comment provided by engineer. */
+"Tag for new Snapshot:" = "Tag pour le nouveau snapshot :";
+
+/* No comment provided by engineer. */
+"There are no VMs in this group so far. Use the + button in the navigation area of the menu bar to add VMs." = "Il n'y a pas de VM dans ce groupe. Utilisez le bouton + dans le menu du panneau de navigation pour ajouter des VM.";
+
+/* No comment provided by engineer. */
+"This image does not contain any snapshots." = "Cette image disque n'a pas de snapshots.";
+
+/* No comment provided by engineer. */
+"This VM does not contain any images." = "Cette VM n'a pas d'images disques.";
+
+/* No comment provided by engineer. */
+"This VM wasn't found. Has it been moved, removed or renamed?" = "VM introuvable. A-t-elle été déplacée, effacée ou renomméee ?";
+
+/* No comment provided by engineer. */
+"VM groups" = "Groupes de VM";
+

--- a/UTM Snapshot-Manager/fr.lproj/UTM Snapshot-Manager-InfoPlist.strings
+++ b/UTM Snapshot-Manager/fr.lproj/UTM Snapshot-Manager-InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle name */
+"CFBundleName" = "UTM Snapshot-Manager";
+


### PR DESCRIPTION
The purpose of this PR is to add french translations to the application and to dynamically select the path to the emu-img binary which would be either in /usr/local/bin/qemu-img (if installed by the UTM app from the Apple Store) or /opt/homebrew/bin/qemu-img (if installed using brew).