### PR TITLE
Use primary and secondary colors

### DIFF
--- a/UTM Snapshot-Manager/UI/VMImageView.swift
+++ b/UTM Snapshot-Manager/UI/VMImageView.swift
@@ -21,7 +21,7 @@ struct VMImageView: View {
     
     var body: some View {
         Label(image.url.lastPathComponent, systemImage: "externaldrive")
-			.foregroundColor(Color.secondary)
+            .foregroundColor(Color.secondary)
             .padding(.leading, VMSectionView.insetNormal)
             .padding(.bottom, VMSectionView.bottomPadding / 2)
             .padding(.top, VMSectionView.bottomPadding / 2)

--- a/UTM Snapshot-Manager/UI/VMImageView.swift
+++ b/UTM Snapshot-Manager/UI/VMImageView.swift
@@ -21,7 +21,7 @@ struct VMImageView: View {
     
     var body: some View {
         Label(image.url.lastPathComponent, systemImage: "externaldrive")
-            .foregroundColor(Color.black.opacity(0.6))
+			.foregroundColor(Color.secondary)
             .padding(.leading, VMSectionView.insetNormal)
             .padding(.bottom, VMSectionView.bottomPadding / 2)
             .padding(.top, VMSectionView.bottomPadding / 2)

--- a/UTM Snapshot-Manager/UI/VMSectionView.swift
+++ b/UTM Snapshot-Manager/UI/VMSectionView.swift
@@ -53,7 +53,7 @@ struct VMSectionView: View {
                 .buttonStyle(RemoveButtonStyle())
                 Text(vm.url.lastPathComponent)
                     .font(Font.system(size: 13, weight: Font.Weight.medium))
-                    .foregroundColor(Color.black)
+					.foregroundColor(Color.primary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 
             }

--- a/UTM Snapshot-Manager/UI/VMSectionView.swift
+++ b/UTM Snapshot-Manager/UI/VMSectionView.swift
@@ -53,7 +53,7 @@ struct VMSectionView: View {
                 .buttonStyle(RemoveButtonStyle())
                 Text(vm.url.lastPathComponent)
                     .font(Font.system(size: 13, weight: Font.Weight.medium))
-					.foregroundColor(Color.primary)
+                    .foregroundColor(Color.primary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 
             }


### PR DESCRIPTION
Forcing `.black` and `.white` does not fit the Dark mode.