### PR TITLE
Display the output in case of runCommandInShell failure

### DIFF
--- a/UTM Snapshot-Manager/QemuImg.swift
+++ b/UTM Snapshot-Manager/QemuImg.swift
@@ -147,6 +147,7 @@ class QemuImg {
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(data: data, encoding: .utf8)!
 
+        task.waitUntilExit()
         if task.terminationStatus != 0 {
             print(output)
         }

--- a/UTM Snapshot-Manager/QemuImg.swift
+++ b/UTM Snapshot-Manager/QemuImg.swift
@@ -146,7 +146,11 @@ class QemuImg {
         
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(data: data, encoding: .utf8)!
-        
+
+        if task.terminationStatus != 0 {
+            print(output)
+        }
+
         return output
     }
 }


### PR DESCRIPTION
For example if qemu-img is not installed I get:
```
zsh:1: no such file or directory: /opt/homebrew/bin/qemu-img
```
instead of nothing and the error is silently ignored.

It would be better to display a **graphical** dialog with the error message. But I am not a SwiftUI expert.